### PR TITLE
ADD: form submission api route

### DIFF
--- a/src/app/api/form/new/route.ts
+++ b/src/app/api/form/new/route.ts
@@ -1,0 +1,33 @@
+import { db } from "@/db";
+import { formSubmissions, answers as dbAnswers } from "@/db/schema";
+
+export async function POST(request: Request): Promise<Response> {
+  const data = await request.json();
+
+  const newFormSubmission = await db
+    .insert(formSubmissions)
+    .values({
+      formId: data.formId,
+    })
+    .returning({
+      insertedId: formSubmissions.id,
+    });
+
+  const [{ insertedId }] = newFormSubmission;
+
+  await db.transaction(async (tx) => {
+    for (const answer of data.answers) {
+      const [{ answerId }] = await tx
+        .insert(dbAnswers)
+        .values({
+          formSubmissionId: insertedId,
+          ...answer,
+        })
+        .returning({
+          answerId: dbAnswers.id,
+        });
+    }
+  });
+
+  return Response.json({ formSubmissionsId: insertedId }, { status: 200 });
+}


### PR DESCRIPTION
This pull request introduces a new API endpoint to handle form submissions. The main changes include adding a new POST method to process and store form data and answers in the database.

New API endpoint:

* [`src/app/api/form/new/route.ts`](diffhunk://#diff-7b4f8234e9cc8de6dfeb1c978c71b0ee2a9240fe5da42acc461434122f5e321dR1-R33): Added a new `POST` method to handle form submissions. This method processes the incoming request, inserts the form submission into the `formSubmissions` table, and then inserts each answer into the `dbAnswers` table within a transaction.