### PR TITLE
ADD: Admin results page

### DIFF
--- a/src/app/(admin)/results/page.tsx
+++ b/src/app/(admin)/results/page.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { getUserForms } from "@/app/actions/getUserForms";
+import { InferSelectModel } from "drizzle-orm";
+import { forms } from "@/db/schema";
+
+type Props = {};
+
+const page = async (props: Props) => {
+  const userForms: Array<InferSelectModel<typeof forms>> = await getUserForms();
+
+  if (!userForms?.length || userForms.length === 0) {
+    return <div>No forms found</div>;
+  }
+
+  const selectOptions = userForms.map((form) => {
+    return {
+      lable: form.name,
+      value: form.id,
+    };
+  });
+
+  return (
+    <div>
+      Results: Dropdown & Tables
+    </div>
+  );
+};
+
+export default page;


### PR DESCRIPTION
This pull request adds a new page component to the admin section of the application. The component fetches user forms and displays a message if no forms are found. If forms are available, it prepares options for a dropdown and renders a placeholder for results.

Key changes:

* Added a new page component in `src/app/(admin)/results/page.tsx` that fetches user forms using `getUserForms` and displays a message if no forms are found.
* Prepared select options from the fetched forms and added a placeholder for displaying results.