### PR TITLE
ADD: Dashboard link to header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,6 +20,9 @@ const Header = async (props: Props) => {
           </h1>
         </div>
         <div className="flex gap-2">
+          <Link href="/view-forms">
+            <Button variant={"link"}>Dashboard</Button>
+          </Link>
           <ModeToggle />
           {session?.user ? (
             <div className="flex items-center gap-2">


### PR DESCRIPTION
This pull request includes a small change to the `Header` component in `src/components/Header.tsx`. The change adds a new link to the "Dashboard" page.

* [`src/components/Header.tsx`](diffhunk://#diff-940a5ae8f5fb47c5c177e82e62f63d31a84d367613d20e22294c818fd4bc562fR23-R25): Added a `Link` component to navigate to the "/view-forms" route with a `Button` labeled "Dashboard".