### PR TITLE
ADD: class for radial gradient 

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,6 +16,9 @@ const config: Config = {
       },
     },
     extend: {
+      backgroundImage: {
+        "gradient-to-c": "radial-gradient(var(--tw-gradient-stops))",
+      },
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",


### PR DESCRIPTION
This pull request includes a small change to the `tailwind.config.ts` file. The change adds a new background image gradient configuration.

* [`tailwind.config.ts`](diffhunk://#diff-655dc9e3d0aa561e3fa164bf48bd89cb0f5da65e0a567f8ebbf9dd791a0e7f40R19-R21): Added a new `backgroundImage` configuration for a radial gradient named `gradient-to-c`.