### PR TITLE
ADD: upgrade account button component

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { SidebarNavItem } from "../types/nav-types";
 import { SessionProvider } from "next-auth/react";
 import FormGenerator from "@/components/FormGenerator";
+import UpgradeAccBtn from "@/components/navigation/UpgradeAccBtn";
 
 export default function AdminLayout({
   children,
@@ -47,6 +48,7 @@ export default function AdminLayout({
       <div className=" grid md:grid-cols-[200px_1fr] flex-1">
         <aside className="hidden w-[200px] flex-col md:flex px-2 py-2 border-r justify-between ">
           <Navbar items={dashboradConfig.sidebarNav} />
+          <UpgradeAccBtn/>
         </aside>
         <main className="flex w-full flex-1 flex-col overflow-hidden">
           <header className="flex items-center">

--- a/src/components/navigation/UpgradeAccBtn.tsx
+++ b/src/components/navigation/UpgradeAccBtn.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import Link from "next/link";
+import { getUserForms } from "@/app/actions/getUserForms";
+import { MAX_FREE_FORMS } from "@/lib/utils";
+import ProgressBar from "../ProgressBar";
+
+type Props = {};
+
+const UpgradeAccBtn = async (props: Props) => {
+  const forms = await getUserForms();
+  const formCount = forms.length;
+  const percent = (formCount / MAX_FREE_FORMS) * 100;
+  console.log(formCount);
+
+  return (
+    <div className="p-4 mb-4 text-sm">
+      <ProgressBar value={percent} />
+      <p>
+        {formCount} out of {MAX_FREE_FORMS} forms generated
+      </p>
+      <p>
+        <Link href={"/setting"} className="underline">
+          Upgrade your plan
+        </Link>{" "}
+        for unlimited forms.
+      </p>
+    </div>
+  );
+};
+
+export default UpgradeAccBtn;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,8 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }
+
+export const MAX_FREE_FORMS = 3;


### PR DESCRIPTION
This pull request introduces a new component `UpgradeAccBtn` to the admin layout and includes some minor code style adjustments. The most important changes are:

### New Feature:

* Added `UpgradeAccBtn` component to display the user's form usage and provide a link to upgrade their plan (`src/components/navigation/UpgradeAccBtn.tsx`).
* Integrated `UpgradeAccBtn` into the admin layout (`src/app/(admin)/layout.tsx`). [[1]](diffhunk://#diff-41a5fc0a14dcc8a7ab836bf5a103ad0942993c15eb1aec8a335da153e6e400d9R7) [[2]](diffhunk://#diff-41a5fc0a14dcc8a7ab836bf5a103ad0942993c15eb1aec8a335da153e6e400d9R51)
