### PR TITLE
FIX: rename route checkoutsession -> checkout-session

### DIFF
--- a/src/app/api/stripe/checkout-session/route.ts
+++ b/src/app/api/stripe/checkout-session/route.ts
@@ -1,0 +1,33 @@
+import { stripe } from "@/lib/stripe";
+import { auth } from "@/auth";
+
+export async function POST(req: Request) {
+  const { price, quantity = 1 } = await req.json();
+  const userSession = await auth();
+  const userId = userSession?.user?.id;
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+
+  const session = await stripe.checkout.sessions.create({
+    success_url: `${baseUrl}/payment/success`,
+    customer: userId,
+    payment_method_types: ["card"],
+    line_items: [
+      {
+        price,
+        quantity,
+      },
+    ],
+    mode: "subscription",
+  });
+
+  if (session) {
+    return new Response(JSON.stringify({ sessionId: session.id }), {
+      status: 200,
+    });
+  } else {
+    return new Response(JSON.stringify({ error: "Failed to create session" }), {
+      status: 500,
+    });
+  }
+}


### PR DESCRIPTION
This pull request introduces a new API endpoint to handle Stripe checkout sessions in the `src/app/api/stripe/checkout-session/route.ts` file. The endpoint is designed to create a new Stripe checkout session for a subscription-based payment.

Key changes:

* Added import statements for `stripe` and `auth` modules.
* Implemented a new `POST` function to handle incoming requests to create a Stripe checkout session. This function extracts the price and quantity from the request body, retrieves the user session, and constructs the Stripe checkout session.
* Configured the checkout session to include success URL, customer ID, payment method types, line items, and mode set to "subscription".
* Added response handling to return the session ID on success or an error message on failure.