### PR TITLE
ADD: Subscribe btn & setup

### DIFF
--- a/src/components/Subscription/SubscribeBtn.tsx
+++ b/src/components/Subscription/SubscribeBtn.tsx
@@ -1,0 +1,45 @@
+"use client";
+import React from "react";
+import { getStripe } from "@/lib/stripe-client";
+import { useSession, signIn } from "next-auth/react";
+import { Button } from "../ui/button";
+import { useRouter } from "next/router";
+
+type Props = {
+  userId?: string;
+  price: number;
+};
+
+const SubscribeBtn = ({ userId, price }: Props) => {
+  const router = useRouter();
+
+  const handleCheckout = async (price: number) => {
+    if (!userId) {
+      router.push("/login");
+    }
+
+    try {
+      const { sessionId } = await fetch("/api/stripe/checkout-session", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ price }),
+      }).then((res) => res.json());
+
+      console.log("sessionId: ", sessionId);
+      const stripe = await getStripe();
+      stripe?.redirectToCheckout({ sessionId });
+    } catch (error) {
+      console.error("Error", error);
+    }
+  };
+
+  return (
+    <Button variant={"link"} onClick={() => handleCheckout(price)}>
+      Upgrade your plan
+    </Button>
+  );
+};
+
+export default SubscribeBtn;

--- a/src/components/navigation/UpgradeAccBtn.tsx
+++ b/src/components/navigation/UpgradeAccBtn.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import Link from "next/link";
 import { getUserForms } from "@/app/actions/getUserForms";
 import { MAX_FREE_FORMS } from "@/lib/utils";
 import ProgressBar from "../ProgressBar";
+import SubscribeBtn from "../Subscription/SubscribeBtn";
+import { auth } from "@/auth";
 
 type Props = {};
 
@@ -10,6 +11,8 @@ const UpgradeAccBtn = async (props: Props) => {
   const forms = await getUserForms();
   const formCount = forms.length;
   const percent = (formCount / MAX_FREE_FORMS) * 100;
+  const session = await auth();
+  const userId = session?.user?.id;
 
   return (
     <div className="p-4 mb-4 text-sm">
@@ -18,9 +21,7 @@ const UpgradeAccBtn = async (props: Props) => {
         {formCount} out of {MAX_FREE_FORMS} forms generated
       </p>
       <p>
-        <Link href={"/setting"} className="underline">
-          Upgrade your plan
-        </Link>{" "}
+        <SubscribeBtn userId={userId} price={22} />
         for unlimited forms.
       </p>
     </div>


### PR DESCRIPTION
This pull request introduces a new `SubscribeBtn` component and integrates it into the `UpgradeAccBtn` component. The changes focus on enhancing the subscription process by adding a button that initiates a checkout session with Stripe.

### New Subscription Button:

* [`src/components/Subscription/SubscribeBtn.tsx`](diffhunk://#diff-6895727868b2ab55fcbd6661d8aa6097f6b8f24f2fe77f59bf6ae234fbfc885bR1-R45): Added a new `SubscribeBtn` component that handles the checkout process using Stripe. The button redirects the user to the login page if they are not authenticated and initiates a Stripe checkout session if they are.

### Integration with Existing Component:

* [`src/components/navigation/UpgradeAccBtn.tsx`](diffhunk://#diff-66d7bdec48df8640e5a97173225ad713f013ef45e1e952c0977a72a569b2a078L2-R15): Replaced the existing link to the settings page with the new `SubscribeBtn` component. This change ensures that users can directly initiate the subscription process from the `UpgradeAccBtn` component. [[1]](diffhunk://#diff-66d7bdec48df8640e5a97173225ad713f013ef45e1e952c0977a72a569b2a078L2-R15) [[2]](diffhunk://#diff-66d7bdec48df8640e5a97173225ad713f013ef45e1e952c0977a72a569b2a078L21-R24)